### PR TITLE
Use smaller python image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "MkDocs-VSCode",
-    "image": "python:3.8.6-buster",
+    "image": "python:3.11.4-slim-buster",
 
     // Set *default* container specific settings.json values on container create.
     "settings": {

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
 ![image](./img/image.gif)
 # MkDocs-with-Remote-Containers
-This repository is a sample to create [MkDocs](https://www.mkdocs.org) document with VSCode [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+This is a sample repository to create [MkDocs](https://www.mkdocs.org) document with VSCode [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
-## Requirements 
+## Requirements
 
-- Visual Studio Code
+- VSCode
 - Remote - Containers (as Visual Studio Code extension)
 - Docker
 


### PR DESCRIPTION
Use `python:3.11.4-slim-buster` as devcontainer image to reduce image size more than 80%.