### PR TITLE
Use Dockerfile to treat 3rd-party plugins

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,6 @@
 FROM python:3.13.3-slim-bookworm
 
 RUN apt-get update && apt-get install -y libsass-dev build-essential git
+
+# Example: Install 3rd party plugin dependencies
+# RUN apt-get install libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev pngquant

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10.4-slim-buster
+
+RUN apt-get update && apt-get install -y libsass-dev build-essential git
+
+#RUN apt-get install -y libcairo2

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,3 @@
-FROM python:3.10.4-slim-buster
+FROM python:3.13.3-slim-bookworm
 
 RUN apt-get update && apt-get install -y libsass-dev build-essential git
-
-#RUN apt-get install -y libcairo2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "MkDocs-VSCode",
-  "image": "python:3.11.4-slim-buster",
+	"dockerFile": "Dockerfile",
   "customizations": {
     "vscode": {
       // Set *default* container specific settings.json values on container create.
@@ -23,7 +23,7 @@
     8000
   ],
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "pip3 install -r requirements.txt"
+  "postCreateCommand": "pip3 install -r .devcontainer/requirements.txt"
   // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
   //"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "MkDocs-VSCode",
-	"dockerFile": "Dockerfile",
+  "dockerFile": "Dockerfile",
   "customizations": {
     "vscode": {
       // Set *default* container specific settings.json values on container create.

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -4,4 +4,4 @@ mkdocs
 # mkdocs-material
 # fontawesome-markdown
 # markdown-include
-# pymdown-extensions 
+# pymdown-extensions

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
             "request": "launch",
             "url": "http://127.0.0.1:8000",
             "preLaunchTask": "mkdocs-serve",
-            "postDebugTask": "mkdocs-stop"
+            "postDebugTask": "mkdocs-stop",
+            "timeout": 100000
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a template repository to create [MkDocs](https://www.mkdocs.org) documen
 
 ## Requirements
 
-- VSCode
+- VSCode or VSCode based IDE like Cursor
 - Dev Containers (as VSCode extension)
 - Docker
 


### PR DESCRIPTION
- Use Dockerfile to manage packages for 3rd-party plugins
- Move requirements.txt to under `.devcontainer` directory

for: https://github.com/hitsumabushi845/MkDocs-with-Remote-Containers/issues/10